### PR TITLE
GitHub Actions for Automated Nightly and Official Releases

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,54 @@
+# File: .github/workflows/nightly-release.yml
+
+name: Nightly Release
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  create-nightly:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install semver
+
+    - name: Determine nightly version
+      id: version
+      run: |
+        current_version=$(python -c "
+        import re
+        with open('uniclip/__init__.py', 'r') as f:
+            content = f.read()
+        match = re.search(r\"__version__\s*=\s*['\\\"]([^'\\\"]*)['\\\"]\", content)
+        if match:
+            print(match.group(1))
+        else:
+            print('0.0.0')  # fallback version
+        ")
+        nightly_version=$(python -c "import semver; v = semver.VersionInfo.parse('$current_version'); print(f'{v.major}.{v.minor}.{v.patch}-nightly.{github.run_number}')")
+        echo "nightly_version=$nightly_version" >> "$GITHUB_OUTPUT"
+
+    - name: Create Nightly Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: nightly-v${{ steps.version.outputs.nightly_version }}
+        release_name: Nightly Release ${{ steps.version.outputs.nightly_version }}
+        draft: false
+        prerelease: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,11 @@
-name: Publish Python Package
+# File: .github/workflows/publish.yml
 
+name: Publish Python Package
 on:
   release:
     types: [published]
-  workflow_dispatch:  # This allows manual triggering
+    tags:
+      - 'v*.*.*'  # This ensures it only runs on official release tags
 
 jobs:
   deploy:
@@ -11,7 +13,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,86 +1,73 @@
-name: Release
+# File: .github/workflows/release.yml
 
+name: Official Release
 on:
-  workflow_dispatch:
-    inputs:
-      release_type:
-        type: choice
-        description: 'Type of release'
-        required: true
-        options:
-        - patch
-        - minor
-        - major
+  workflow_dispatch:  # This allows manual triggering without inputs
 
 jobs:
-  release:
+  official-release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install semver
 
-    - name: Determine new version
+    - name: Get latest nightly release
+      id: latest_nightly
+      run: |
+        latest_nightly=$(git describe --tags --match "nightly-v*" --abbrev=0)
+        echo "latest_nightly=$latest_nightly" >> "$GITHUB_OUTPUT"
+
+    - name: Determine official version
       id: version
       run: |
-        current_version=$(python -c "
-        import re
-        with open('uniclip/__init__.py', 'r') as f:
-            content = f.read()
-        match = re.search(r\"__version__\s*=\s*['\\\"]([^'\\\"]*)['\\\"]\", content)
-        if match:
-            print(match.group(1))
-        else:
-            print('0.0.0')  # fallback version
-        ")
-        new_version=$(python -c "import semver; print(str(semver.VersionInfo.parse('$current_version').bump_${{ github.event.inputs.release_type }}()))")
-        echo "Current version: $current_version"
-        echo "New version will be: $new_version"
-        echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
-        
+        nightly_version="${{ steps.latest_nightly.outputs.latest_nightly }}"
+        official_version=$(echo $nightly_version | sed 's/nightly-v//' | sed 's/-nightly\..*//')
+        echo "official_version=$official_version" >> "$GITHUB_OUTPUT"
+
     - name: Update version
       run: |
-        sed -i "s/__version__\s*=\s*['\"].*['\"]/__version__ = '${{ steps.version.outputs.new_version }}'/" uniclip/__init__.py
-        
+        sed -i "s/__version__\s*=\s*['\"].*['\"]/__version__ = '${{ steps.version.outputs.official_version }}'/" uniclip/__init__.py
+
     - name: Commit version update
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add uniclip/__init__.py
-        git commit -m "Bump ${{ github.event.inputs.release_type }} version to ${{ steps.version.outputs.new_version }}"
-        
+        git commit -m "Bump version to ${{ steps.version.outputs.official_version }}"
+
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: ${{ github.ref }}
-        
-    - name: Create Release
+
+    - name: Create Official Release
       id: create_release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: v${{ steps.version.outputs.new_version }}
-        release_name: Release ${{ steps.version.outputs.new_version }}
+        tag_name: v${{ steps.version.outputs.official_version }}
+        release_name: Release ${{ steps.version.outputs.official_version }}
         draft: false
         prerelease: false
-        
+
     - name: Update README
       run: |
-        sed -i "s/Current version: .*/Current version: ${{ steps.version.outputs.new_version }}/" README.md
+        sed -i "s/Current version: .*/Current version: ${{ steps.version.outputs.official_version }}/" README.md
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add README.md
-        git commit -m "Update version in README to ${{ steps.version.outputs.new_version }}"
+        git commit -m "Update version in README to ${{ steps.version.outputs.official_version }}"
         git push


### PR DESCRIPTION


## Overview
This PR refactors our GitHub Actions workflows to implement a new release strategy. The new approach automates the creation of nightly releases and simplifies the process of creating official releases.

## Changes

### 1. New Workflow: Nightly Releases (`nightly-release.yml`)
- Automatically creates a nightly release on every push to the main branch and on every pull request.
- Generates a version number in the format `X.Y.Z-nightly.{run_number}`.
- Creates a GitHub pre-release with the nightly version tag.

### 2. Modified Workflow: Official Releases (`release.yml`)
- Updated to automatically select the latest nightly release when triggered.
- Removes the need for manual input of the nightly release tag.
- Creates an official release based on the latest nightly, updating version numbers in files.

### 3. Modified Workflow: Package Publishing (`publish.yml`)
- Now triggers only on official release tags (v*.*.*).
- Publishes the package to PyPI when an official release is created.

## Benefits
1. **Automated Nightly Builds**: Provides easy access to the latest changes for testing.
2. **Simplified Release Process**: Official releases can be created with a single click, without manual version selection.
3. **Consistent Versioning**: Ensures a clear progression from nightly to official releases.
4. **Automated Publishing**: Reduces manual steps in the release process.

## How to Use
1. Nightly releases will be automatically created on pushes and pull requests.
2. To create an official release:
   a. Go to the "Actions" tab in the GitHub repository.
   b. Select the "Official Release" workflow.
   c. Click "Run workflow" without any additional input.
3. The publish workflow will automatically triggered